### PR TITLE
LM-3196 - Paritally reverts PR #19 

### DIFF
--- a/client/Lykke.Service.HftInternalService.Client/Keys/ApiKeyModel.cs
+++ b/client/Lykke.Service.HftInternalService.Client/Keys/ApiKeyModel.cs
@@ -8,6 +8,9 @@ namespace Lykke.Service.HftInternalService.Client.Keys
     [PublicAPI]
     public class ApiKeyModel
     {
+        /// <summary>ID of the key</summary>
+        public string Id { get; set; }
+
         /// <summary>
         /// The API key of the wallet.
         /// </summary>

--- a/src/Lykke.Service.HftInternalService.Services/Handlers/ApiKeyHandler.cs
+++ b/src/Lykke.Service.HftInternalService.Services/Handlers/ApiKeyHandler.cs
@@ -50,7 +50,7 @@ namespace Lykke.Service.HftInternalService.Services.Handlers
                 await _apiKeyRepository.Update(existedApiKey);
                 await _keysPublisher.PublishAsync(new KeyUpdatedEvent
                 {
-                    Id =  existedApiKey.Token ?? existedApiKey.Id.ToString(),
+                    Id =  existedApiKey.Id.ToString(),
                     IsDeleted = true,
                     Apiv2Only = existedApiKey.Apiv2Only,
                     ClientId = existedApiKey.ClientId,
@@ -93,7 +93,7 @@ namespace Lykke.Service.HftInternalService.Services.Handlers
 
             await _keysPublisher.PublishAsync(new KeyUpdatedEvent
             {
-                Id = key.Token ?? key.Id.ToString(),
+                Id = key.Id.ToString(),
                 IsDeleted = false,
                 Apiv2Only = key.Apiv2Only,
                 ClientId = key.ClientId,
@@ -125,7 +125,7 @@ namespace Lykke.Service.HftInternalService.Services.Handlers
 
                 await _keysPublisher.PublishAsync(new KeyUpdatedEvent
                 {
-                    Id = existedApiKey.Token ?? existedApiKey.Id.ToString(),
+                    Id = existedApiKey.Id.ToString(),
                     IsDeleted = true,
                     Apiv2Only = existedApiKey.Apiv2Only,
                     ClientId = existedApiKey.ClientId,

--- a/src/Lykke.Service.HftInternalService/Models/v2/ApiKeyDto.cs
+++ b/src/Lykke.Service.HftInternalService/Models/v2/ApiKeyDto.cs
@@ -5,6 +5,9 @@
     /// </summary>
     public class ApiKeyDto
     {
+        /// <summary>ID of the key</summary>
+        public string Id { get; set; }
+
         /// <summary>The API key</summary>
         public string ApiKey { get; set; }
 

--- a/src/Lykke.Service.HftInternalService/Modules/ApiKeyProfile.cs
+++ b/src/Lykke.Service.HftInternalService/Modules/ApiKeyProfile.cs
@@ -12,14 +12,15 @@ namespace Lykke.Service.HftInternalService.Modules
         public ApiKeyProfile()
         {
             CreateMap<ApiKey, Models.V2.ApiKeyDto>()
-                .ForMember(dto => dto.ApiKey, m => m.MapFrom(o => string.IsNullOrEmpty(o.Token) ? o.Id.ToString() :o.Token))
+                .ForMember(dto => dto.Id, m => m.MapFrom(o => o.Id))
+                .ForMember(dto => dto.ApiKey, m => m.MapFrom(o => string.IsNullOrEmpty(o.Token) ? o.Id.ToString() : o.Token))
                 .ForMember(dto => dto.WalletId, m => m.MapFrom(o => o.WalletId))
                 .ForMember(dto => dto.ClientId, m => m.MapFrom(o => o.ClientId))
                 .ForMember(dto => dto.Enabled, m => m.MapFrom(o => !o.ValidTill.HasValue))
                 .ForMember(dto => dto.Apiv2Only, m => m.MapFrom(o => o.Apiv2Only));
 
             CreateMap<ApiKey, Models.v1.ApiKeyDto>()
-                .ForMember(dto => dto.Key, m => m.MapFrom(o => string.IsNullOrEmpty(o.Token) ? o.Id.ToString() :o.Token))
+                .ForMember(dto => dto.Key, m => m.MapFrom(o => string.IsNullOrEmpty(o.Token) ? o.Id.ToString() : o.Token))
                 .ForMember(dto => dto.Wallet, m => m.MapFrom(o => o.WalletId))
                 .ForMember(dto => dto.Apiv2Only, m => m.MapFrom(o => o.Apiv2Only));
         }


### PR DESCRIPTION
This PR paritally reverts PR #19 in regards to how `KeyUpdatedEvent.Id` is evaluated - it turned out that for HFT API v2 it should be always just Id and never token.

Additionally it adds API key ID to the API v2 response